### PR TITLE
Fix use of getHeaderByName

### DIFF
--- a/DjangoCsrfToken.js
+++ b/DjangoCsrfToken.js
@@ -2,8 +2,7 @@
 var CsrfToken = function() {
     this.evaluate = function(context) {
         var request = context.getCurrentRequest(),
-            headers = request.getHeaders(),
-            cookies = headers['Cookie'].split(';'),
+            cookies = request.getHeaderByName('Cookie').split(';'),
             token = null;
 
         for (var index in cookies) {


### PR DESCRIPTION
It's nicer to use `request.getHeaderByName('Cookie ')` instead of `request.getHeaders()['Cookie']` for 2 reasons:
- it prevents the evaluation of all headers, even for those not required (calculates all instead of only one)
- it doesn't do case-insensitive comparison (header names are case-insensitive in HTTP)

Also ended the file with a new line (sorry, too much used to it...a UNIX standard...). Thanks a bunch for your work on this!
