### PR TITLE
Fix JS bug when missing Cookie header

### DIFF
--- a/DjangoCsrfToken.js
+++ b/DjangoCsrfToken.js
@@ -2,7 +2,7 @@
 var CsrfToken = function() {
     this.evaluate = function(context) {
         var request = context.getCurrentRequest(),
-            cookies = request.getHeaderByName('Cookie').split(';'),
+            cookies = (request.getHeaderByName('Cookie') || '').split(';'),
             token = null;
 
         for (var index in cookies) {


### PR DESCRIPTION
Fixes a JavaScript error when there's a missing `Cookie` header
